### PR TITLE
Cache npm packages

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -36,6 +36,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: "16"
+        cache: npm
     - name: Get Datadog CLI
       shell: bash
       run: npm install -g @datadog/datadog-ci


### PR DESCRIPTION
Try and cache NPM packages to speed up downloading `datadog-ci`