### PR TITLE
Fix tag uploads for junit test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,7 @@ jobs:
           files: ./ci/fixtures/
           service: junit-upload-github-action
           env: ci
+          tags: "foo:bar,alpha:bravo"
       - name: Tag pipeline with ci version
         run: |
           datadog-ci tag --level pipeline --tags "datadogci.version:`npm list -g @datadog/datadog-ci | grep @datadog/datadog-ci | awk -F' ' '{print $2}' | awk -F'@' '{print $3}' | tr -d '\n'`"

--- a/action.yaml
+++ b/action.yaml
@@ -49,7 +49,6 @@ runs:
       run: |
         datadog-ci junit upload \
           --service ${{ inputs.service }} \
-          --tags "${{ inputs.tags }}" \
           --logs \
           --max-concurrency ${{ inputs.concurrency }} \
           ${{ inputs.files }}
@@ -57,16 +56,17 @@ runs:
         DATADOG_API_KEY: ${{ inputs.api-key }}
         DATADOG_SITE: ${{ inputs.datadog-site }}
         DD_ENV: ${{ inputs.env }}
+        DD_TAGS: ${{ inputs.tags }}
     - name: Upload the JUnit files
       if: ${{ inputs.logs != 'true' }}
       shell: bash
       run: |
         datadog-ci junit upload \
           --service ${{ inputs.service }} \
-          --tags "${{ inputs.tags }}" \
           --max-concurrency ${{ inputs.concurrency }} \
           ${{ inputs.files }}
       env:
         DATADOG_API_KEY: ${{ inputs.api-key }}
         DATADOG_SITE: ${{ inputs.datadog-site }}
         DD_ENV: ${{ inputs.env }}
+        DD_TAGS: ${{ inputs.tags }}


### PR DESCRIPTION
Fix issue reported in #10 that incorrectly sets the tags for the tests. Using the env var `DD_TAGS` instead of the terminal option `--tags` saves us having to parse the input.