### PR TITLE
Added option to input extra args to the datadog-ci command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ The action has the following options:
 | `tags` | Optional extra tags to add to the tests | False | |
 | `env` | Optional environment to add to the tests | False | |
 | `logs` | When set to "true" enables forwarding content from the XML reports as Logs. The content inside `<system-out>`, `<system-err>`, and `<failure>` is collected as logs. Logs from elements inside a `<testcase>` are automatically connected to the test. | False | |
-| `skip-git-metadata-upload` | When set to "true" it will skip sending your git metadata with your XML report. | False | 'false'|
+| `extra-args` | Extra args to be passed to the datadog-ci junit upload command.| False | |

--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ The action has the following options:
 | `tags` | Optional extra tags to add to the tests | False | |
 | `env` | Optional environment to add to the tests | False | |
 | `logs` | When set to "true" enables forwarding content from the XML reports as Logs. The content inside `<system-out>`, `<system-err>`, and `<failure>` is collected as logs. Logs from elements inside a `<testcase>` are automatically connected to the test. | False | |
+| `skip-git-metadata-upload` | When set to "true" it will skip sending your git metadata with your XML report. | False | 'false'|

--- a/action.yaml
+++ b/action.yaml
@@ -33,6 +33,10 @@ inputs:
   logs:
     required: false
     description: Set to "true" to enable forwarding content from XML reports as logs.
+  skip-git-metadata-upload:
+    required: false
+    description: Set to "true" to skip sending your git metadata with your XML report.
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -51,6 +55,7 @@ runs:
           --service ${{ inputs.service }} \
           --logs \
           --max-concurrency ${{ inputs.concurrency }} \
+          ----skip-git-metadata-upload ${{ inputs.skip-git-metadata-upload == 'true' }} \
           ${{ inputs.files }}
       env:
         DATADOG_API_KEY: ${{ inputs.api-key }}
@@ -64,6 +69,7 @@ runs:
         datadog-ci junit upload \
           --service ${{ inputs.service }} \
           --max-concurrency ${{ inputs.concurrency }} \
+          --skip-git-metadata-upload ${{ inputs.skip-git-metadata-upload == 'true' }} \
           ${{ inputs.files }}
       env:
         DATADOG_API_KEY: ${{ inputs.api-key }}

--- a/action.yaml
+++ b/action.yaml
@@ -55,7 +55,7 @@ runs:
           --service ${{ inputs.service }} \
           --logs \
           --max-concurrency ${{ inputs.concurrency }} \
-          ----skip-git-metadata-upload ${{ inputs.skip-git-metadata-upload == 'true' }} \
+          --skip-git-metadata-upload ${{ inputs.skip-git-metadata-upload == 'true' }} \
           ${{ inputs.files }}
       env:
         DATADOG_API_KEY: ${{ inputs.api-key }}

--- a/action.yaml
+++ b/action.yaml
@@ -33,10 +33,10 @@ inputs:
   logs:
     required: false
     description: Set to "true" to enable forwarding content from XML reports as logs.
-  skip-git-metadata-upload:
+  extra-args:
+    default: ''
+    description: Extra args to be passed to the datadog-ci cli.
     required: false
-    description: Set to "true" to skip sending your git metadata with your XML report.
-    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -55,7 +55,7 @@ runs:
           --service ${{ inputs.service }} \
           --logs \
           --max-concurrency ${{ inputs.concurrency }} \
-          --skip-git-metadata-upload ${{ inputs.skip-git-metadata-upload == 'true' }} \
+          ${{ inputs.extra-args }} \
           ${{ inputs.files }}
       env:
         DATADOG_API_KEY: ${{ inputs.api-key }}
@@ -69,7 +69,7 @@ runs:
         datadog-ci junit upload \
           --service ${{ inputs.service }} \
           --max-concurrency ${{ inputs.concurrency }} \
-          --skip-git-metadata-upload ${{ inputs.skip-git-metadata-upload == 'true' }} \
+          ${{ inputs.extra-args }} \
           ${{ inputs.files }}
       env:
         DATADOG_API_KEY: ${{ inputs.api-key }}


### PR DESCRIPTION
This change introduces the option to add an input to pass extra arguments as a string to the cli command

