### PR TITLE
Bump to actions/setup-node@v4 and node v20 as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ jobs:
 
 The action has the following options:
 
-| Name | Description | Required | Default         |
-| ---- | ----------- | -------- |-----------------|
-| `api-key` | Datadog API key to use to upload the junit files. | True |                 |
-| `service` | Service name to use with the uploaded test results. | True |                 |
+| Name | Description | Required | Default |
+| ---- | ----------- | -------- | ------- |
+| `api-key` | Datadog API key to use to upload the junit files. | True | |
+| `service` | Service name to use with the uploaded test results. | True | |
 | `datadog-site` | The Datadog site to upload the files to. | True | `datadoghq.com` |
-| `files` | Path to file or folder containing XML files to upload | True | `.`             |
-| `concurrency` | Controls the maximum number of concurrent file uploads | True | `20`            |
-| `node-version` | The node version to use to install the datadog-ci. It must be `>=10.24.1` | True | `20`            |
-| `tags` | Optional extra tags to add to the tests | False |                 |
-| `env` | Optional environment to add to the tests | False |                 |
-| `logs` | When set to "true" enables forwarding content from the XML reports as Logs. The content inside `<system-out>`, `<system-err>`, and `<failure>` is collected as logs. Logs from elements inside a `<testcase>` are automatically connected to the test. | False |                 |
-| `extra-args` | Extra args to be passed to the datadog-ci junit upload command.| False |                 |
+| `files` | Path to file or folder containing XML files to upload | True | `.` |
+| `concurrency` | Controls the maximum number of concurrent file uploads | True | `20` |
+| `node-version` | The node version to use to install the datadog-ci. It must be `>=10.24.1` | True | `20` |
+| `tags` | Optional extra tags to add to the tests | False | |
+| `env` | Optional environment to add to the tests | False | |
+| `logs` | When set to "true" enables forwarding content from the XML reports as Logs. The content inside `<system-out>`, `<system-err>`, and `<failure>` is collected as logs. Logs from elements inside a `<testcase>` are automatically connected to the test. | False | |
+| `extra-args` | Extra args to be passed to the datadog-ci junit upload command.| False | |

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ jobs:
 
 The action has the following options:
 
-| Name | Description | Required | Default |
-| ---- | ----------- | -------- | ------- |
-| `api-key` | Datadog API key to use to upload the junit files. | True | |
-| `service` | Service name to use with the uploaded test results. | True | |
+| Name | Description | Required | Default         |
+| ---- | ----------- | -------- |-----------------|
+| `api-key` | Datadog API key to use to upload the junit files. | True |                 |
+| `service` | Service name to use with the uploaded test results. | True |                 |
 | `datadog-site` | The Datadog site to upload the files to. | True | `datadoghq.com` |
-| `files` | Path to file or folder containing XML files to upload | True | `.` |
-| `concurrency` | Controls the maximum number of concurrent file uploads | True | `20` |
-| `node-version` | The node version to use to install the datadog-ci. It must be `>=10.24.1` | True | `16` |
-| `tags` | Optional extra tags to add to the tests | False | |
-| `env` | Optional environment to add to the tests | False | |
-| `logs` | When set to "true" enables forwarding content from the XML reports as Logs. The content inside `<system-out>`, `<system-err>`, and `<failure>` is collected as logs. Logs from elements inside a `<testcase>` are automatically connected to the test. | False | |
-| `extra-args` | Extra args to be passed to the datadog-ci junit upload command.| False | |
+| `files` | Path to file or folder containing XML files to upload | True | `.`             |
+| `concurrency` | Controls the maximum number of concurrent file uploads | True | `20`            |
+| `node-version` | The node version to use to install the datadog-ci. It must be `>=10.24.1` | True | `20`            |
+| `tags` | Optional extra tags to add to the tests | False |                 |
+| `env` | Optional environment to add to the tests | False |                 |
+| `logs` | When set to "true" enables forwarding content from the XML reports as Logs. The content inside `<system-out>`, `<system-err>`, and `<failure>` is collected as logs. Logs from elements inside a `<testcase>` are automatically connected to the test. | False |                 |
+| `extra-args` | Extra args to be passed to the datadog-ci junit upload command.| False |                 |

--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ inputs:
   node-version:
     required: true
     description: The node version used to install datadog-ci
-    default: "16"
+    default: "20"
   tags:
     required: false
     description: Datadog tags to associate with the uploaded test results.
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Install node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
     - name: Get Datadog CLI


### PR DESCRIPTION
Because of https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/