### PR TITLE
Update naming of input variables

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,6 @@ jobs:
         uses: ./
         id: test_step
         with:
-          api-key: ${{secrets.DD_API_KEY_CI_VISIBILITY}}
           logs: "true"
           files: '**/fixtures/**'
           service: junit-upload-github-action-tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
           files: '**/fixtures/**'
           service: junit-upload-github-action-tests
           env: ci
-          tags: "foo:bar,alpha:bravo"
+          tags: "foo:previous,alpha:previous"
           datadog-ci-version: ${{ env.SECOND_LATEST_VERSION }}
       - name: Check that test data can be queried
         run: |
@@ -73,6 +73,7 @@ jobs:
         uses: ./
         id: test_step
         with:
+          api-key: ${{secrets.DD_API_KEY_CI_VISIBILITY}}
           logs: "true"
           files: '**/fixtures/**'
           service: junit-upload-github-action-tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - 'release/*'
-      - juan-fernandez/rename-inputs # to remove before merging
   schedule:
     - cron: '0 0 * * *' # Runs at midnight UTC every day
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
           npm install @datadog/datadog-api-client
           node ./check-junit-upload.js
         env:
-          EXTRA_TAGS: "@foo:bar @alpha:bravo @test.node.version:${{ matrix.version}}"
+          EXTRA_TAGS: "@foo:previous @alpha:previous"
           DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
           DD_APP_KEY: ${{ secrets.DD_APP_KEY_CI_VISIBILITY }}
           DD_SERVICE: junit-upload-github-action-tests
@@ -71,6 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Upload reports using a glob pattern
         uses: ./
+        id: test_step
         with:
           logs: "true"
           files: '**/fixtures/**'
@@ -79,9 +80,7 @@ jobs:
           tags: "foo:bar,alpha:bravo"
         continue-on-error: true
       - name: Check that previous step failed
-        if: success()
-        run: echo "This step should not run" && exit 1
-      - name: Check that previous step failed
-        if: failure()
-        run: echo "Previous step failed as expected" 
-        
+        if: steps.test_step.outcome == 'success'
+        run: |
+          echo "The previous step did not fail as expected"
+          exit 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'release/*'
+      - juan-fernandez/rename-inputs # to remove before merging
   schedule:
     - cron: '0 0 * * *' # Runs at midnight UTC every day
 
@@ -46,11 +47,41 @@ jobs:
       - name: Upload reports using a glob pattern
         uses: ./
         with:
-          api_key: ${{secrets.DD_API_KEY_CI_VISIBILITY}}
+          # should still work with api-key as input
+          api-key: ${{secrets.DD_API_KEY_CI_VISIBILITY}}
           logs: "true"
           files: '**/fixtures/**'
           service: junit-upload-github-action-tests
           env: ci
           tags: "foo:bar,alpha:bravo"
           datadog-ci-version: ${{ env.SECOND_LATEST_VERSION }}
-      
+      - name: Check that test data can be queried
+        run: |
+          npm install @datadog/datadog-api-client
+          node ./check-junit-upload.js
+        env:
+          EXTRA_TAGS: "@foo:bar @alpha:bravo @test.node.version:${{ matrix.version}}"
+          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
+          DD_APP_KEY: ${{ secrets.DD_APP_KEY_CI_VISIBILITY }}
+          DD_SERVICE: junit-upload-github-action-tests
+
+  test-should-complain-about-missing-api-key:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload reports using a glob pattern
+        uses: ./
+        with:
+          logs: "true"
+          files: '**/fixtures/**'
+          service: junit-upload-github-action-tests
+          env: ci
+          tags: "foo:bar,alpha:bravo"
+        continue-on-error: true
+      - name: Check that previous step failed
+        if: success()
+        run: echo "This step should not run" && exit 1
+      - name: Check that previous step failed
+        if: failure()
+        run: echo "Previous step failed as expected" 
+        

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Upload reports using a glob pattern
         uses: ./
         with:
-          api-key: ${{secrets.DD_API_KEY_CI_VISIBILITY}}
+          api_key: ${{secrets.DD_API_KEY_CI_VISIBILITY}}
           logs: "true"
           files: '**/fixtures/**'
           service: junit-upload-github-action-tests
@@ -46,7 +46,7 @@ jobs:
       - name: Upload reports using a glob pattern
         uses: ./
         with:
-          api-key: ${{secrets.DD_API_KEY_CI_VISIBILITY}}
+          api_key: ${{secrets.DD_API_KEY_CI_VISIBILITY}}
           logs: "true"
           files: '**/fixtures/**'
           service: junit-upload-github-action-tests

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
       - run: make tests
       - uses: datadog/junit-upload-github-action@v1
         with:
-            api-key: ${{ secrets.DD_API_KEY }}
+            api_key: ${{ secrets.DD_API_KEY }}
             service: my-app
             files: ./reports/
 ```
@@ -29,9 +29,9 @@ The action has the following options:
 
 | Name | Description | Required | Default |
 | ---- | ----------- | -------- | ------- |
-| `api-key` | Datadog API key to use to upload the junit files. | True | |
+| `api_key` | Datadog API key to use to upload the junit files. | True | |
 | `service` | Service name to use with the uploaded test results. | True | |
-| `datadog-site` | The Datadog site to upload the files to. | True | `datadoghq.com` |
+| `site` | The Datadog site to upload the files to. | True | `datadoghq.com` |
 | `files` | Path to file or folder containing XML files to upload | True | `.` |
 | `concurrency` | Controls the maximum number of concurrent file uploads | True | `20` |
 | `node-version` | The node version to use to install the datadog-ci. It must be `>=14` | True | `20` |

--- a/action.yaml
+++ b/action.yaml
@@ -63,8 +63,6 @@ runs:
         if [ -z "${{ inputs.api_key }}" ] && [ -z "${{ inputs.api-key }}" ]; then
           echo "Error: Both api_key and api-key are undefined. At least one must be defined."
           exit 1
-        else
-          echo "Inputs are valid."
         fi
     - name: Upload the JUnit files
       if: ${{ inputs.logs == 'true' }}

--- a/action.yaml
+++ b/action.yaml
@@ -3,13 +3,20 @@ name: "Datadog JUnitXML Upload"
 description: "Upload JUnitXML reports files to Datadog CI Visibility"
 inputs:
   api-key:
-    required: true
+    required: false
+    description: (Deprecated) Datadog API key to use to upload the junit files.
+  api_key:
+    required: false
     description: Datadog API key to use to upload the junit files.
   service:
     required: true
     description: Service name to use with the uploaded test results.
   datadog-site:
-    required: true
+    required: false
+    default: datadoghq.com
+    description: (Deprecated) The Datadog site to upload the files to.
+  site:
+    required: false
     default: datadoghq.com
     description: The Datadog site to upload the files to.
   files:
@@ -48,6 +55,15 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
+    - name: Check if input values are correct
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.api_key }}" ] && [ -z "${{ inputs.api-key }}" ]; then
+          echo "Error: Both api_key and api-key are undefined. At least one must be defined."
+          exit 1
+        else
+          echo "Inputs are valid."
+        fi
     - name: Upload the JUnit files
       if: ${{ inputs.logs == 'true' }}
       shell: bash
@@ -59,8 +75,8 @@ runs:
           ${{ inputs.extra-args }} \
           ${{ inputs.files }}
       env:
-        DATADOG_API_KEY: ${{ inputs.api-key }}
-        DATADOG_SITE: ${{ inputs.datadog-site }}
+        DATADOG_API_KEY: ${{ inputs.api_key != '' && inputs.api_key || inputs.api-key }}
+        DATADOG_SITE: ${{ inputs.site != '' && inputs.site || inputs.datadog-site }}
         DD_ENV: ${{ inputs.env }}
         DD_TAGS: ${{ inputs.tags }}
     - name: Upload the JUnit files
@@ -73,7 +89,7 @@ runs:
           ${{ inputs.extra-args }} \
           ${{ inputs.files }}
       env:
-        DATADOG_API_KEY: ${{ inputs.api-key }}
-        DATADOG_SITE: ${{ inputs.datadog-site }}
+        DATADOG_API_KEY: ${{ inputs.api_key != '' && inputs.api_key || inputs.api-key }}
+        DATADOG_SITE: ${{ inputs.site != '' && inputs.site || inputs.datadog-site }}
         DD_ENV: ${{ inputs.env }}
         DD_TAGS: ${{ inputs.tags }}

--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,7 @@ inputs:
   api-key:
     required: false
     description: (Deprecated) Datadog API key to use to upload the junit files.
+    deprecationMessage: "This input is deprecated. Use `api_key` instead."
   api_key:
     required: false
     description: Datadog API key to use to upload the junit files.
@@ -15,6 +16,7 @@ inputs:
     required: false
     default: datadoghq.com
     description: (Deprecated) The Datadog site to upload the files to.
+    deprecationMessage: "This input is deprecated. Use `site` instead."
   site:
     required: false
     default: datadoghq.com


### PR DESCRIPTION
* From `api-key` to `api_key`
* From `datadog-site` to `site`

This is part of an effort to bring consistency to input values in Datadog actions. 