### PR TITLE
doc: specify the expected format for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The action has the following options:
 | `files` | Path to file or folder containing XML files to upload | True | `.` |
 | `concurrency` | Controls the maximum number of concurrent file uploads | True | `20` |
 | `node-version` | The node version to use to install the datadog-ci. It must be `>=14` | True | `20` |
-| `tags` | Optional extra tags to add to the tests | False | |
+| `tags` | Optional extra tags to add to the tests formmatted as a comma separated list of tags. | False | |
 | `env` | Optional environment to add to the tests | False | |
 | `logs` | When set to "true" enables forwarding content from the XML reports as Logs. The content inside `<system-out>`, `<system-err>`, and `<failure>` is collected as logs. Logs from elements inside a `<testcase>` are automatically connected to the test. | False | |
 | `datadog-ci-version` | Optionally pin the @datadog/datadog-ci version. | False | `latest` |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The action has the following options:
 | `files` | Path to file or folder containing XML files to upload | True | `.` |
 | `concurrency` | Controls the maximum number of concurrent file uploads | True | `20` |
 | `node-version` | The node version to use to install the datadog-ci. It must be `>=14` | True | `20` |
-| `tags` | Optional extra tags to add to the tests formmatted as a comma separated list of tags. | False | |
+| `tags` | Optional extra tags to add to the tests formatted as a comma separated list of tags. Example: `foo:bar,data:dog` | False | |
 | `env` | Optional environment to add to the tests | False | |
 | `logs` | When set to "true" enables forwarding content from the XML reports as Logs. The content inside `<system-out>`, `<system-err>`, and `<failure>` is collected as logs. Logs from elements inside a `<testcase>` are automatically connected to the test. | False | |
 | `datadog-ci-version` | Optionally pin the @datadog/datadog-ci version. | False | `latest` |


### PR DESCRIPTION
The documentation do not specify the expected format for tags with the action.

Looking at the code, we can see that the input ends in a DD_TAGS env variable and the [documentation](https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=noncontainerizedenvironments#:~:text=If%20you%20specify%20multiple%20tags%2C%20separate%20each%20one%20with%20a%20space) specifies that the separator is a space in DD_TAGS env var. But when using the space separator, the resulting tags in datadog for the uploaded tags is not properlly parsed.

Testing out of curiosity with a comma separator worked, so I guess the documentation should clarify the expected format.