### PR TITLE
feat: replace npx with pre-built standalone binary verified via SHA256

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
           service: junit-upload-github-action-tests
           env: ci
           tags: "foo:bar,alpha:bravo,test.node.version:${{ matrix.version}}"
-          node-version: ${{ matrix.version}}
+
       - name: Check that test data can be queried
         run: |
           npm install @datadog/datadog-api-client
@@ -42,7 +42,7 @@ jobs:
       - name: Grab second latest version of @datadog/datadog-ci
         run: |
           SECOND_LATEST_VERSION=$(curl -s "https://api.github.com/repos/datadog/datadog-ci/releases" | jq '[.[] | {tag_name: .tag_name, published_at: .published_at}] | sort_by(.published_at) | reverse | .[:2] | .[1] | .tag_name')
-          echo "SECOND_LATEST_VERSION=$SECOND_LATEST_VERSION" >> $GITHUB_ENV
+          echo "SECOND_LATEST_VERSION=$SECOND_LATEST_VERSION" >> "$GITHUB_ENV"
       - name: Upload reports using a glob pattern
         uses: ./
         with:
@@ -71,6 +71,7 @@ jobs:
         uses: ./
         id: test_step
         with:
+          api_key: ""
           logs: "true"
           files: '**/fixtures/**'
           service: junit-upload-github-action-tests

--- a/action.yaml
+++ b/action.yaml
@@ -24,10 +24,6 @@ inputs:
     required: true
     description: Controls the maximum number of concurrent file uploads.
     default: "20"
-  node-version:
-    required: true
-    description: The node version used to install datadog-ci
-    default: "20"
   tags:
     required: false
     description: Datadog tags to associate with the uploaded test results.
@@ -42,8 +38,18 @@ inputs:
     description: Set to "true" to enable forwarding content from XML reports as logs.
   datadog-ci-version:
     required: false
-    description: The version of the @datadog/datadog-ci package to use. It defaults to the latest release (`latest`).
-    default: "latest"
+    description: >
+      The version of the datadog-ci standalone binary to download from GitHub Releases.
+      Defaults to 5.9.1 (pinned for supply-chain safety). Do not use "latest" — pin
+      to a specific version so checksum verification is deterministic.
+    default: "5.9.1"
+  platform:
+    required: false
+    description: >
+      Target platform binary to download from GitHub Releases. Available options:
+      linux-x64, linux-arm64, darwin-x64, darwin-arm64, win-x64.
+      Defaults to linux-x64 which covers most GitHub-hosted and self-hosted runners.
+    default: "linux-x64"
   extra-args:
     default: ""
     description: Extra args to be passed to the datadog-ci cli.
@@ -51,15 +57,23 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install node
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ inputs.node-version }}
+    - name: Download and verify datadog-ci binary
+      shell: bash
+      run: |
+        set -euo pipefail
+        curl -fsSL -o datadog-ci \
+          "https://github.com/DataDog/datadog-ci/releases/download/v${{ inputs.datadog-ci-version }}/datadog-ci_${{ inputs.platform }}"
+        curl -fsSL -o checksums.txt \
+          "https://github.com/DataDog/datadog-ci/releases/download/v${{ inputs.datadog-ci-version }}/checksums.txt"
+        grep "datadog-ci_${{ inputs.platform }}" checksums.txt \
+          | sed "s|datadog-ci_${{ inputs.platform }}|datadog-ci|" \
+          | sha256sum --check
+        chmod +x datadog-ci
 
     - name: Upload the JUnit files
       shell: bash
       run: |
-        npx @datadog/datadog-ci@${{ inputs.datadog-ci-version}} junit upload \
+        ./datadog-ci junit upload \
           --max-concurrency ${{ inputs.concurrency }} \
           ${{ inputs.logs == 'true' && '--logs' || '' }} \
           ${{ inputs.auto-discovery == 'true' && '--auto-discovery' || '' }} \


### PR DESCRIPTION
- Remove node-version input and actions/setup-node step; no Node.js required at runtime anymore.
- Add platform input (default: linux-x64) to select the right binary.
- Download datadog-ci standalone binary from GitHub Releases and verify its integrity against the published checksums.txt before execution.
- Pin default datadog-ci-version to 5.9.1 for deterministic checksum verification; callers should pin to a known-good version.
- Update test.yaml: remove node-version input (now gone), quote $GITHUB_ENV (shellcheck SC2086), add empty api_key to satisfy actionlint static analysis on the negative test job.

Later improvement could had a github action to regularly check release of new datadog-ci and generate a PR that upgrade datadog-ci-version in this workflow. Considering risk of running npm stuff this days, the less we run it the better.