### PR TITLE
Make action releases follow datadog-ci semver

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Process
 
-This repository ships a composite GitHub Action. Releases are Git tags: immutable semver tags such as `v3.0.1`, plus a moving major tag such as `v3`.
+This repository ships a composite GitHub Action. Releases are Git tags: immutable semver tags such as `v3.1.0`, plus a moving major tag such as `v3`.
 
 ## Bump datadog-ci
 
@@ -28,7 +28,13 @@ After a `datadog-ci-version-bump` PR is merged, run:
 scripts/release-datadog-ci-bump.sh
 ```
 
-The script fetches `main` and tags, finds the latest merged PR with the `datadog-ci-version-bump` label that is on `main` but not included in the latest immutable action tag, and releases that merge commit. A release creates the next patch tag, updates the moving major tag, and creates a GitHub Release.
+The script fetches `main` and tags, finds the latest merged PR with the `datadog-ci-version-bump` label that is on `main` but not included in the latest immutable action tag, and releases that merge commit. The action version follows the `datadog-ci` change:
+
+- floating `v5` to the first pinned `v5.x.y`: action minor bump
+- `datadog-ci` minor bump: action minor bump
+- `datadog-ci` patch bump: action patch bump
+
+The release creates the next immutable action tag, updates the moving major tag, and creates a GitHub Release.
 
 Preview the release without creating tags or a GitHub Release:
 

--- a/scripts/release-datadog-ci-bump.sh
+++ b/scripts/release-datadog-ci-bump.sh
@@ -6,9 +6,10 @@ usage() {
 Usage: scripts/release-datadog-ci-bump.sh [--dry-run] [--pr NUMBER | --sha COMMIT]
 
 Finds the latest merged datadog-ci bump PR on main that is not included in the
-latest immutable action release tag. When one exists, creates the next patch
-action tag, updates the moving major tag, and creates a GitHub Release. If older
-unreleased bump PRs exist, the script warns and releases only the latest change.
+latest immutable action release tag. When one exists, creates the next action
+minor or patch tag, updates the moving major tag, and creates a GitHub Release.
+If older unreleased bump PRs exist, the script warns and releases only the latest
+change.
 
 Options:
   --dry-run      Print the release that would be created.
@@ -193,9 +194,52 @@ else
   release_source="$release_sha"
 fi
 
+extract_datadog_ci_version() {
+  local ref="$1"
+
+  git show "$ref:action.yaml" | ruby -ryaml -e 'puts YAML.load($stdin.read).fetch("inputs").fetch("datadog-ci-version").fetch("default")'
+}
+
+is_exact_datadog_ci_version() {
+  [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+semver_parts() {
+  local version="${1#v}"
+  IFS=. read -r semver_major semver_minor semver_patch <<< "$version"
+  echo "$semver_major $semver_minor $semver_patch"
+}
+
+latest_datadog_ci_version=$(extract_datadog_ci_version "$latest_tag")
+release_datadog_ci_version=$(extract_datadog_ci_version "$release_sha")
+
+if ! is_exact_datadog_ci_version "$release_datadog_ci_version"; then
+  echo "Expected datadog-ci-version default to be an exact release tag at $release_sha, got '$release_datadog_ci_version'" >&2
+  exit 1
+fi
+
+action_bump_kind="minor"
+if is_exact_datadog_ci_version "$latest_datadog_ci_version"; then
+  read -r latest_dd_major latest_dd_minor latest_dd_patch <<< "$(semver_parts "$latest_datadog_ci_version")"
+  read -r release_dd_major release_dd_minor release_dd_patch <<< "$(semver_parts "$release_datadog_ci_version")"
+
+  if (( release_dd_major == latest_dd_major && release_dd_minor == latest_dd_minor && release_dd_patch > latest_dd_patch )); then
+    action_bump_kind="patch"
+  elif (( release_dd_major > latest_dd_major || (release_dd_major == latest_dd_major && release_dd_minor > latest_dd_minor) )); then
+    action_bump_kind="minor"
+  else
+    echo "Expected datadog-ci-version at $release_sha ('$release_datadog_ci_version') to be newer than the latest released default ('$latest_datadog_ci_version')." >&2
+    exit 1
+  fi
+fi
+
 version="${latest_tag#v}"
 IFS=. read -r major minor patch <<< "$version"
-next_tag="v${major}.${minor}.$((patch + 1))"
+if [[ "$action_bump_kind" == "minor" ]]; then
+  next_tag="v${major}.$((minor + 1)).0"
+else
+  next_tag="v${major}.${minor}.$((patch + 1))"
+fi
 major_tag="v${major}"
 
 if git rev-parse --verify --quiet "refs/tags/$next_tag" >/dev/null; then
@@ -208,16 +252,10 @@ if gh release view "$next_tag" --repo "$repo" >/dev/null 2>&1; then
   exit 1
 fi
 
-datadog_ci_version=$(git show "$release_sha:action.yaml" | ruby -ryaml -e 'puts YAML.load($stdin.read).fetch("inputs").fetch("datadog-ci-version").fetch("default")')
-if [[ ! "$datadog_ci_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Expected datadog-ci-version default to be an exact release tag at $release_sha, got '$datadog_ci_version'" >&2
-  exit 1
-fi
-
 notes_file=$(mktemp)
 trap 'rm -f "$notes_file"' EXIT
 cat > "$notes_file" <<EOF
-Updates the default \`datadog-ci-version\` to \`$datadog_ci_version\`.
+Updates the default \`datadog-ci-version\` from \`$latest_datadog_ci_version\` to \`$release_datadog_ci_version\`.
 
 Triggered by $release_source
 EOF
@@ -227,12 +265,14 @@ fi
 
 echo "Latest action release tag: $latest_tag"
 echo "Next action release tag: $next_tag"
+echo "Action bump kind: $action_bump_kind"
 echo "Moving major tag: $major_tag"
 echo "Release commit: $release_sha"
 if [[ -n "$release_pr_number" ]]; then
   echo "Release PR: #$release_pr_number"
 fi
-echo "datadog-ci version: $datadog_ci_version"
+echo "Latest released datadog-ci version: $latest_datadog_ci_version"
+echo "Release datadog-ci version: $release_datadog_ci_version"
 
 if [[ "$dry_run" == "true" ]]; then
   echo "Dry run only. No tags or GitHub Release were created."


### PR DESCRIPTION
## Summary

Follow up from https://github.com/DataDog/junit-upload-github-action/pull/54

- Make `scripts/release-datadog-ci-bump.sh` choose the action version bump from the pinned `datadog-ci` change.
- Treat the transition from floating `v5` to the first pinned `v5.x.y` as an action minor bump.
- Keep following `datadog-ci` semver after that:
  - `datadog-ci` minor bump => action minor bump
  - `datadog-ci` patch bump => action patch bump
- Update `RELEASE.md` to document the release-versioning policy.

## Why

With the current script, the merged `#54` bump would release `v3.0.1` even though it is the first time the action moves from a floating default (`v5`) to an exact pinned `datadog-ci` version. We want that transition to cut `v3.1.0`, and after that we want action releases to mirror the shape of the `datadog-ci` update.

## Behavior

For the current repository state, the updated dry run now reports:

- latest action release tag: `v3.0.0`
- next action release tag: `v3.1.0`
- action bump kind: `minor`
- latest released `datadog-ci` version: `v5`
- release `datadog-ci` version: `v5.14.0`

This PR should **not** carry the `datadog-ci-version-bump` label. That label should stay on `#54`, since `#54` is the PR whose merge commit should be released.
