### PR TITLE
Use GitHub-generated release notes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,7 +34,7 @@ The script fetches `main` and tags, finds the latest merged PR with the `datadog
 - `datadog-ci` minor bump: action minor bump
 - `datadog-ci` patch bump: action patch bump
 
-The release creates the next immutable action tag, updates the moving major tag, and creates a GitHub Release.
+The release creates the next immutable action tag, updates the moving major tag, and creates a GitHub Release with GitHub-generated release notes starting from the previous immutable action tag.
 
 Preview the release without creating tags or a GitHub Release:
 

--- a/scripts/release-datadog-ci-bump.sh
+++ b/scripts/release-datadog-ci-bump.sh
@@ -252,17 +252,6 @@ if gh release view "$next_tag" --repo "$repo" >/dev/null 2>&1; then
   exit 1
 fi
 
-notes_file=$(mktemp)
-trap 'rm -f "$notes_file"' EXIT
-cat > "$notes_file" <<EOF
-Updates the default \`datadog-ci-version\` from \`$latest_datadog_ci_version\` to \`$release_datadog_ci_version\`.
-
-Triggered by $release_source
-EOF
-if [[ -n "$release_pr_merged_at" ]]; then
-  echo "Merged at: $release_pr_merged_at" >> "$notes_file"
-fi
-
 echo "Latest action release tag: $latest_tag"
 echo "Next action release tag: $next_tag"
 echo "Action bump kind: $action_bump_kind"
@@ -286,6 +275,7 @@ git push --force "$remote" "refs/tags/$major_tag"
 
 gh release create "$next_tag" \
   --repo "$repo" \
-  --target "$release_sha" \
   --title "$next_tag" \
-  --notes-file "$notes_file"
+  --verify-tag \
+  --generate-notes \
+  --notes-start-tag "$latest_tag"


### PR DESCRIPTION
## Summary

- Change `scripts/release-datadog-ci-bump.sh` to create releases with GitHub-generated release notes instead of a custom handwritten body.
- Use the previous immutable action tag as the release-notes starting point.
- Update `RELEASE.md` to document that releases now use GitHub-generated notes.

## Why

The current release script creates a minimal custom release body, which does not match the format GitHub generates when using the “Generate release notes” button. Using GitHub-generated notes gives the action releases the standard structure and compare-based changelog users already expect.

## Behavior

The release script now calls `gh release create` with:

- `--generate-notes`
- `--notes-start-tag <previous immutable tag>`
- `--verify-tag`

That keeps the existing tag-creation flow while making the published release notes follow GitHub’s default generated format.
