### PR TITLE
Fix datadog-ci major version resolution

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -61,10 +61,9 @@ runs:
         echo "version=${translated_version}" >> "$GITHUB_OUTPUT"
 
     - name: Install datadog-ci
-      uses: DataDog/install-datadog-ci-github-action@7960c07e413c56665e12346b34eec80089a7260e # v1.0.2
+      uses: DataDog/install-datadog-ci-github-action@4b24cd8614f96f36c45a6c10425ede3691de637d # v1.0.3
       with:
         version: ${{ steps.translate-version.outputs.version }}
-        github-token: ${{ inputs.github-token != '' && inputs.github-token || github.token }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token != '' && inputs.github-token || github.token }}
 

--- a/action.yaml
+++ b/action.yaml
@@ -61,7 +61,7 @@ runs:
         echo "version=${translated_version}" >> "$GITHUB_OUTPUT"
 
     - name: Install datadog-ci
-      uses: DataDog/install-datadog-ci-github-action@6d7f0c7c5402a4b1912055b76970ca76bef71fe5
+      uses: DataDog/install-datadog-ci-github-action@6d7f0c7c5402a4b1912055b76970ca76bef71fe5 # v1.0.4
       with:
         version: ${{ steps.translate-version.outputs.version }}
         github-token: ${{ inputs.github-token != '' && inputs.github-token || github.token }}

--- a/action.yaml
+++ b/action.yaml
@@ -61,9 +61,10 @@ runs:
         echo "version=${translated_version}" >> "$GITHUB_OUTPUT"
 
     - name: Install datadog-ci
-      uses: DataDog/install-datadog-ci-github-action@4b24cd8614f96f36c45a6c10425ede3691de637d # v1.0.3
+      uses: DataDog/install-datadog-ci-github-action@6d7f0c7c5402a4b1912055b76970ca76bef71fe5
       with:
         version: ${{ steps.translate-version.outputs.version }}
+        github-token: ${{ inputs.github-token != '' && inputs.github-token || github.token }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token != '' && inputs.github-token || github.token }}
 


### PR DESCRIPTION
## Summary
Bump `DataDog/install-datadog-ci-github-action` to the `v1.0.4` commit SHA.

## Why
The legacy syntax test translates `>=5.0.0` to `v5`. The previously pinned installer action could exit while resolving floating major versions like `v5`. `install-datadog-ci-github-action@v1.0.4` includes the hardened resolver and declares the `github-token` input.

More context: https://github.com/DataDog/install-datadog-ci-github-action/pull/9
