### PR TITLE
Avoid inherited tag signing in release script

### DIFF
--- a/scripts/release-action.sh
+++ b/scripts/release-action.sh
@@ -294,8 +294,8 @@ if [[ "$dry_run" == "true" ]]; then
   exit 0
 fi
 
-git tag "$next_tag" "$target_sha"
-git tag -f "$major_tag" "$target_sha"
+git tag --no-sign "$next_tag" "$target_sha"
+git tag --no-sign -f "$major_tag" "$target_sha"
 git push "$remote" "refs/tags/$next_tag"
 git push --force "$remote" "refs/tags/$major_tag"
 


### PR DESCRIPTION
## Summary

- Add `--no-sign` to the release script's immutable and moving-major `git tag` commands.

## Why

The release script creates lightweight action tags and then pushes them to GitHub. If a developer has `tag.gpgsign=true` in their Git config, plain `git tag <tag> <sha>` is interpreted as a signed annotated tag creation instead of the lightweight tag the script expects.

That changes the command contract and can fail with `fatal: no tag message?` because the script does not provide an annotated tag message. Passing `--no-sign` makes the script's existing lightweight-tag behavior explicit and keeps global Git config from changing release behavior.

This also applies to the moving major tag, since `v3` is intentionally force-updated and should follow the same explicit tag creation semantics as before.

## Validation

- `bash -n scripts/release-action.sh`
- `git verify-commit HEAD`