### PR TITLE
Pin test workflow actions to SHAs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
   test-default-datadog-ci-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check PR has a semver release label
         if: github.event_name == 'pull_request'
         run: |
@@ -50,7 +50,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Upload reports using a glob pattern
         uses: ./
         with:
@@ -77,7 +77,7 @@ jobs:
         # Test backwards compatibility with legacy npm semver syntax
         version: ["latest", "^5.0.0", "~5.0.0", ">=5.0.0", "5.x"]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Sanitize version for tag
         id: sanitize
         run: |
@@ -109,7 +109,7 @@ jobs:
   test-older-datadog-ci-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Grab second latest version of @datadog/datadog-ci
         env:
           GH_TOKEN: ${{ github.token }}
@@ -156,7 +156,7 @@ jobs:
   test-should-complain-about-missing-api-key:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Upload reports using a glob pattern
         uses: ./
         id: test_step

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
   test-default-datadog-ci-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Check PR has a semver release label
         if: github.event_name == 'pull_request'
         run: |
@@ -50,7 +50,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Upload reports using a glob pattern
         uses: ./
         with:
@@ -77,7 +77,7 @@ jobs:
         # Test backwards compatibility with legacy npm semver syntax
         version: ["latest", "^5.0.0", "~5.0.0", ">=5.0.0", "5.x"]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Sanitize version for tag
         id: sanitize
         run: |
@@ -109,7 +109,7 @@ jobs:
   test-older-datadog-ci-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Grab second latest version of @datadog/datadog-ci
         env:
           GH_TOKEN: ${{ github.token }}
@@ -156,7 +156,7 @@ jobs:
   test-should-complain-about-missing-api-key:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Upload reports using a glob pattern
         uses: ./
         id: test_step

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
   test-default-datadog-ci-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Check PR has a semver release label
         if: github.event_name == 'pull_request'
         run: |
@@ -50,7 +50,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Upload reports using a glob pattern
         uses: ./
         with:
@@ -77,7 +77,7 @@ jobs:
         # Test backwards compatibility with legacy npm semver syntax
         version: ["latest", "^5.0.0", "~5.0.0", ">=5.0.0", "5.x"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Sanitize version for tag
         id: sanitize
         run: |
@@ -109,7 +109,7 @@ jobs:
   test-older-datadog-ci-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Grab second latest version of @datadog/datadog-ci
         env:
           GH_TOKEN: ${{ github.token }}
@@ -156,7 +156,7 @@ jobs:
   test-should-complain-about-missing-api-key:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Upload reports using a glob pattern
         uses: ./
         id: test_step


### PR DESCRIPTION
## Summary

- Upgrade all five `actions/checkout` uses in `.github/workflows/test.yaml` to `v7.0.0`.
- Pin them to the immutable commit `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`.
- Keep `# v7.0.0` comments beside the SHAs for readability and dependency update tooling.

## Why

Moving major tags can change after review, while the existing v4 release uses the deprecated Node.js 20 action runtime. Using the latest release at an immutable commit keeps the workflow current and ensures it runs the exact revision that was reviewed.

## User impact

No intended product behavior change. The test workflow now uses the Node.js 24-based `actions/checkout` v7 release.

## Verification

- `git diff --check`
- Parsed `.github/workflows/test.yaml` with Ruby YAML
- Verified all five checkout references use the v7.0.0 commit SHA and no moving checkout references remain
- Verified every PR commit signature with `git verify-commit`

`actionlint` was not run because it is not installed locally.
